### PR TITLE
Update Free Usage Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is the official Ruby client library for the [IPinfo.io](https://ipinfo.io) 
 
 You'll need an IPinfo API access token, which you can get by singing up for a free account at [https://ipinfo.io/signup](https://ipinfo.io/signup?ref=lib-Ruby).
 
-The free plan is limited to 1,000 requests a day, and doesn't include some of the data fields such as IP type and company data. To enable all the data fields and additional request volumes see [https://ipinfo.io/pricing](https://ipinfo.io/pricing?ref=lib-Ruby)
+The free plan is limited to 50,000 requests per month, and doesn't include some of the data fields such as IP type and company data. To enable all the data fields and additional request volumes see [https://ipinfo.io/pricing](https://ipinfo.io/pricing?ref=lib-Ruby)
 
 #### Installation
 


### PR DESCRIPTION
Based on https://ipinfo.io/developers#rate-limits, free usage is limited to 50,000 API requests per month.