### PR TITLE
Update to faraday 1.x

### DIFF
--- a/ipinfo.gemspec
+++ b/ipinfo.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  spec.add_runtime_dependency 'faraday', '~> 0'
+  spec.add_runtime_dependency 'faraday', '~> 1'
   spec.add_runtime_dependency 'lrucache', '~> 0.1.4'
   spec.add_runtime_dependency 'json', '~> 2.1'
 

--- a/lib/ipinfo.rb
+++ b/lib/ipinfo.rb
@@ -28,12 +28,12 @@ module IPinfo
 
     def initialize(access_token=nil, settings={})
       @access_token = access_token
-      @http_client = http_client(settings.fetch("http_client", nil))
+      @http_client = my_http_client(settings.fetch("http_client", nil))
 
       maxsize = settings.fetch("maxsize", DEFAULT_CACHE_MAXSIZE)
       ttl = settings.fetch("ttl", DEFAULT_CACHE_TTL)
       @cache = settings.fetch("cache", DefaultCache.new(ttl, maxsize))
-      @countries = countries(settings.fetch('countries', DEFAULT_COUNTRY_FILE))
+      @countries = my_countries(settings.fetch('countries', DEFAULT_COUNTRY_FILE))
     end
 
     def details(ip_address=nil)
@@ -68,7 +68,7 @@ module IPinfo
       @cache.get(ip_address)
     end
 
-    def http_client(http_client=nil)
+    def my_http_client(http_client=nil)
       if http_client
         @http_client = Adapter.new(access_token, http_client)
       else
@@ -76,7 +76,7 @@ module IPinfo
       end
     end
 
-    def countries(filename)
+    def my_countries(filename)
       file = File.read(filename)
       JSON.parse(file)
     end

--- a/lib/ipinfo/response.rb
+++ b/lib/ipinfo/response.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'pry'
 
 require 'ipaddr'
 require 'json'
@@ -13,7 +14,9 @@ module IPinfo
 
       @all.each do |name, value|
         instance_variable_set("@#{name}", value)
-        self.class.send(:attr_accessor, name)
+        unless self.respond_to?(name)
+          self.class.send(:attr_accessor, name)
+        end
       end
     end
   end

--- a/lib/ipinfo/version.rb
+++ b/lib/ipinfo/version.rb
@@ -1,3 +1,3 @@
 module IPinfo
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/test/lib/adapter_test.rb
+++ b/test/lib/adapter_test.rb
@@ -5,7 +5,7 @@ require_relative '../../lib/ipinfo/adapter'
 class IPinfo::AdapterTest < Minitest::Test
   def test_default
     adapter = IPinfo::Adapter.new
-    assert(adapter.conn.builder.handlers[0] === Faraday::Adapter::NetHttp)
+    assert(adapter.conn.builder.adapter === Faraday::Adapter::NetHttp)
   end
 
   SUPPORTED_ADAPTERS = {
@@ -27,7 +27,7 @@ class IPinfo::AdapterTest < Minitest::Test
   def test_all_possible_adapters
     SUPPORTED_ADAPTERS.keys.each do |key|
       adapter = IPinfo::Adapter.new(nil, key)
-      assert(adapter.conn.builder.handlers[0] === SUPPORTED_ADAPTERS[key])
+      assert(adapter.conn.builder.adapter === SUPPORTED_ADAPTERS[key])
     end
   end
 end


### PR DESCRIPTION
Hi, I needed a version of the IPinfo gem with a faraday version > v1 because our project relies on this. For this reason I made some changes and bumped the version to 0.2.0.