### PR TITLE
Use more recent gem for caching

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :development do
   gem 'minitest-vcr'
   gem 'minitest-reporters'
   gem 'webmock'
+  gem 'lru_redux'
 
   platforms :mri do
     # to avoid problems, bring Byebug in on just versions of Ruby under which

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ details.all = {
 
 #### Caching
 
-In-memory caching of `details` data is provided by default via the [lrucache](https://www.rubydoc.info/gems/lrucache/0.1.4/LRUCache) gem. This uses an LRU (least recently used) cache with a TTL (time to live) by default. This means that values will be cached for the specified duration; if the cache's max size is reached, cache values will be invalidated as necessary, starting with the oldest cached value.
+In-memory caching of `details` data is provided by default via the [lru_redux](https://github.com/SamSaffron/lru_redux) gem. This uses an LRU (least recently used) cache with a TTL (time to live) by default. This means that values will be cached for the specified duration; if the cache's max size is reached, cache values will be invalidated as necessary, starting with the oldest cached value.
 
 ##### Modifying cache options
 

--- a/ipinfo.gemspec
+++ b/ipinfo.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_runtime_dependency 'faraday', '~> 0'
-  spec.add_runtime_dependency 'lrucache', '~> 0.1.4'
   spec.add_runtime_dependency 'json', '~> 2.1'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|

--- a/lib/ipinfo/cache/default_cache.rb
+++ b/lib/ipinfo/cache/default_cache.rb
@@ -1,11 +1,11 @@
 require 'ipinfo/cache/cache_interface'
-require 'lrucache'
+require 'lru_redux'
 
 module IPinfo
   class DefaultCache < CacheInterface
 
     def initialize(ttl, max_size)
-      @cache = LRUCache.new(:ttl => ttl, :max_size => max_size)
+		@cache = LruRedux::TTL::Cache.new(max_size, ttl)
     end
 
     def get(key)

--- a/lib/ipinfo/version.rb
+++ b/lib/ipinfo/version.rb
@@ -1,3 +1,3 @@
 module IPinfo
-  VERSION = "0.1.1"
+  VERSION = "0.1.3"
 end


### PR DESCRIPTION
Replace the old lrucache gem with [lru_redux](https://github.com/SamSaffron/lru_redux), as newer versions of Ruby can't compile the dependencies of lrucache (see #16).