### PR TITLE
Bump faraday version

### DIFF
--- a/ipinfo.gemspec
+++ b/ipinfo.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_runtime_dependency 'faraday', '~> 1'
-  spec.add_runtime_dependency 'json', '~> 2.1'
+  spec.add_runtime_dependency 'json', '~> 2'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})

--- a/ipinfo.gemspec
+++ b/ipinfo.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
       "public gem pushes."
   end
 
-  spec.add_runtime_dependency 'faraday', '~> 0'
+  spec.add_runtime_dependency 'faraday', '~> 1'
   spec.add_runtime_dependency 'json', '~> 2.1'
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
Bundler could not find compatible versions for gem "faraday":
  In snapshot (Gemfile.lock):
    faraday (= 1.0.1)

  In Gemfile:
    ipinfo-rails was resolved to 0.1.1, which depends on
      IPinfo (~> 0.1.2) was resolved to 0.1.2, which depends on
        faraday (~> 0)

    faraday_middleware was resolved to 1.0.0, which depends on
      faraday (~> 1.0)