### PR TITLE
Uninstall lru_redux and install sin_lru_redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ details.all = {
 #### Caching
 
 In-memory caching of `details` data is provided by default via the
-[`lru_redux`](https://github.com/SamSaffron/lru_redux) gem. This uses an LRU
+[`sin_lru_redux`](https://github.com/cadenza-tech/sin_lru_redux) gem. This uses an LRU
 (least recently used) cache with a TTL (time to live) by default. This means
 that values will be cached for the specified duration; if the cache's max size
 is reached, cache values will be invalidated as necessary, starting with the

--- a/ipinfo.gemspec
+++ b/ipinfo.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency 'faraday-excon', '~> 2.1'
 
     spec.add_runtime_dependency 'json', '~> 2.1'
-    spec.add_runtime_dependency 'lru_redux', '~> 1.1'
+    spec.add_runtime_dependency 'sin_lru_redux'
 
     spec.files = `git ls-files -z`.split("\x0").reject do |f|
         f.match(%r{^(test|spec|features)/})

--- a/lib/ipinfo/cache/default_cache.rb
+++ b/lib/ipinfo/cache/default_cache.rb
@@ -5,7 +5,7 @@ require 'lru_redux'
 
 class IPinfo::DefaultCache < IPinfo::CacheInterface
     def initialize(ttl, max_size)
-        @cache = LruRedux::TTL::Cache.new(max_size, ttl)
+        @cache = LruRedux::TTL::Cache.new(max_size, ttl, true)
     end
 
     def get(key)


### PR DESCRIPTION
## What's changed

- Uninstall lru_redux and install sin_lru_redux because lru_redux is not maintained over 10 years
- Set ignore_nil to true for saving memory
