### PR TITLE
Fix `request_details` in `isBogon` case for `IPinfoLite`

### DIFF
--- a/lib/ipinfo_lite.rb
+++ b/lib/ipinfo_lite.rb
@@ -50,10 +50,10 @@ class IPinfo::IPinfoLite
 
     def request_details(ip_address = nil)
         if ip_address && ip_address != 'me' && isBogon(ip_address)
+            details = {}
             details[:ip] = ip_address
             details[:bogon] = true
             details[:ip_address] = IPAddr.new(ip_address)
-
             return details
         end
 


### PR DESCRIPTION
Same fix as #49 but for Lite API class.