### PR TITLE
Update Bulgaria currency from BGN to EUR

### DIFF
--- a/lib/ipinfo/countriesData.rb
+++ b/lib/ipinfo/countriesData.rb
@@ -559,7 +559,7 @@ module CountriesData
         "BD" => {"code" => "BDT" ,"symbol" => "৳"},
         "BE" => {"code" => "EUR" ,"symbol" => "€"},
         "BF" => {"code" => "XOF" ,"symbol" => "CFA"},
-        "BG" => {"code" => "BGN" ,"symbol" => "лв"},
+        "BG" => {"code" => "EUR" ,"symbol" => "€"},
         "BH" => {"code" => "BHD" ,"symbol" => ".د.ب"},
         "BI" => {"code" => "BIF" ,"symbol" => "FBu"},
         "BJ" => {"code" => "XOF" ,"symbol" => "CFA"},


### PR DESCRIPTION
Bulgaria adopted the Euro starting 1/1/26, this PR changes the country currency code and symbol to reflect that.